### PR TITLE
Update PanSN specification to use full string for `haplotype_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ The use of strings for `haplotype_id` allows for clear representation of various
 
 - **Haplotype 1/Haplotype 2**. Used when both haplotype assemblies are comparably complete, but parental origin is unknown (example: `hifiasm` or `verkko` with Hi-C phasing): `HG002#hap1#ctg1234` and `HG002#hap2#ctg5678`
 
-- **Maternal/Paternal**. Used when both haplotypes are comparably complete, and their parental origins for all chromosomes are known (example: `hifiasm` or `verkko` with trio phasing): `HG002#1#ctg1234` and `HG002#2#ctg5678`
-New: HG002#mat#ctg1234 and HG002#pat#ctg5678
+- **Maternal/Paternal**. Used when both haplotypes are comparably complete, and their parental origins for all chromosomes are known (example: `hifiasm` or `verkko` with trio phasing): `HG002#mat#ctg1234` and `HG002#pat#ctg5678`
 
 - **Merged assemblies**. Used when both haplotypes are combined to create one merged assembly (example: many past assemblers): `HG002#mer#ctg1234`
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ where
 ```
 sample_name := string
 delim := character
-haplotype_id := number
+haplotype_id := string
 contig_or_scaffold_name := string
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ Tools supporting PanSN should allow the user to change the delimiter.
 
 The prefixing should provide a unique hierachy of sample names and haplotype identifiers for the entire pangenome under analysis.
 
+### haplotype_id
+
+The use of strings for `haplotype_id` allows for clear representation of various assembly types and scenarios. Here are detailed examples based on common labeling practices from Vertebrate Genome Project (VGP) and Earth BioGenome Project (EBP):
+
+- **Primary/Alternate assemblies**. Used when one assembly is much more complete than the other haplotype (example: `hifiasm` without Hi-C or trio phasing): `HG002#1#ctg1234` and `HG002#2#ctg5678`
+
+- **Haplotype 1/Haplotype 2**. Used when both haplotype assemblies are comparably complete, but parental origin is unknown (example: `hifiasm` or `verkko` with Hi-C phasing): `HG002#hap1#ctg1234` and `HG002#hap2#ctg5678`
+
+- **Maternal/Paternal**. Used when both haplotypes are comparably complete, and their parental origins for all chromosomes are known (example: `hifiasm` or `verkko` with trio phasing): `HG002#1#ctg1234` and `HG002#2#ctg5678`
+New: HG002#mat#ctg1234 and HG002#pat#ctg5678
+
+- **Merged assemblies**. Used when both haplotypes are combined to create one merged assembly (example: many past assemblers): `HG002#mer#ctg1234`
+
 ## deeper motivation
 
 When working with pangenomes it becomes necessary to maintain simple metadata about the origins of each sequence.


### PR DESCRIPTION
Following discussions within the HPRC (Human Pangenome Reference Consortium), we propose updating the PanSN specification to use full strings instead of integers for haplotype identifiers (`haplotype_id`). This change addresses several needs identified by consortium members:

- Clear distinction between different assembly types (primary/alternate, haplotype 1/2, maternal/paternal, merged)
- Support for various assembly scenarios (e.g., `hifiasm`/`verkko` with different phasing methods)
- Improved human readability and immediate understanding of haplotype nature/origin

This change may require updates to tools that strictly adhere to the previous integer-based specification, such as those working with GFA W lines or VCFs.